### PR TITLE
Add null mapping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: ["3.8", "3.9", "3.10"]
         os: [macos-latest, windows-latest, ubuntu-latest]
         experimental: [false]
 

--- a/fastavro_gen/type_gen.py
+++ b/fastavro_gen/type_gen.py
@@ -16,6 +16,7 @@ PRIMITIVE_TO_TYPE: Dict[str, str] = {
     "boolean": "bool",
     "float": "float",
     "double": "float",
+    "null": "None"
 }
 
 PATTERN = re.compile(r"(?<!^)(?=[A-Z])")

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,7 +1,7 @@
 import nox
 
 
-@nox.session(python=["3.8", "3.9"])
+@nox.session(python=["3.8", "3.9", "3.10"])
 def test(session):
     session.install("fastavro", "black", "pytest")
     session.install(".")
@@ -16,6 +16,7 @@ def test(session):
 
 @nox.session
 def typecheck(session):
+    session.install("types-toml")
     session.install("mypy")
 
     session.run("mypy", "--ignore-missing-imports", "fastavro_gen")

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-version = "0.0.1"
+version = "0.0.2"
 
 
 setup(


### PR DESCRIPTION
I have a quite complicated Avro schema which looks like that in Avro IDL:
```typescript
union{null, map<union {null, boolean, long, double, string}>} row_values_before_change = null;
```
The second `null` type in the second `union` breaks the current implementation. This fix adds the proper mapping for `null` values.