### PR TITLE
Added support for Decimal logical type

### DIFF
--- a/fastavro_gen/__init__.py
+++ b/fastavro_gen/__init__.py
@@ -5,3 +5,4 @@ import fastavro_gen.from_dict as from_dict
 generate = gen.read_schemas_and_generate_classes
 asdict = as_dict
 fromdict = from_dict.fromdict
+

--- a/fastavro_gen/logical_types.py
+++ b/fastavro_gen/logical_types.py
@@ -1,0 +1,5 @@
+LOGICAL_TYPE_MAP = {
+    # logicalType: (typename, import-module, parse-expression)
+    "decimal":        ("Decimal",        "decimal",        "Decimal(val)"),
+    # add more as needed and if not supported by fast avro
+}

--- a/fastavro_gen/logical_types.py
+++ b/fastavro_gen/logical_types.py
@@ -1,5 +1,71 @@
+from decimal import Decimal
+from datetime import date, time, datetime, timedelta, timezone
+
+def _parse_time_millis(ms: int) -> time:
+    # ms since midnight → a time object
+    return (datetime.min + timedelta(milliseconds=ms)).time()
+
+def _parse_time_micros(us: int) -> time:
+    # µs since midnight → a time object
+    return (datetime.min + timedelta(microseconds=us)).time()
+
+def _parse_local_timestamp_millis(ms: int) -> datetime:
+    # ms since epoch → naive local datetime (no TZ)
+    return datetime.utcfromtimestamp(ms / 1000)
+
+def _parse_local_timestamp_micros(us: int) -> datetime:
+    # µs since epoch → naive local datetime (no TZ)
+    return datetime.utcfromtimestamp(us / 1_000_000)
+
+def _parse_timestamp_millis(ms: int) -> datetime:
+    # ms since epoch → aware UTC datetime
+    return datetime.fromtimestamp(ms / 1000, tz=timezone.utc)
+
+def _parse_timestamp_micros(us: int) -> datetime:
+    # µs since epoch → aware UTC datetime
+    return datetime.fromtimestamp(us / 1_000_000, tz=timezone.utc)
+
+
 LOGICAL_TYPE_MAP = {
-    # logicalType: (typename, import-module, parse-expression)
-    "decimal":        ("Decimal",        "decimal",        "Decimal(val)"),
-    # add more as needed and if not supported by fast avro
+    # logicalType: (typename, import-module, parser_func)
+    "date": (
+        "date",
+        "datetime",
+        date.fromisoformat,       # expects "YYYY-MM-DD"
+    ),
+    "time-millis": (
+        "time",
+        "datetime",
+        _parse_time_millis,
+    ),
+    "time-micros": (
+        "time",
+        "datetime",
+        _parse_time_micros,
+    ),
+    "timestamp-millis": (
+        "datetime",
+        "datetime",
+        _parse_timestamp_millis,
+    ),
+    "timestamp-micros": (
+        "datetime",
+        "datetime",
+        _parse_timestamp_micros,
+    ),
+    "local-timestamp-millis": (
+        "datetime",
+        "datetime",
+        _parse_local_timestamp_millis,
+    ),
+    "local-timestamp-micros": (
+        "datetime",
+        "datetime",
+        _parse_local_timestamp_micros,
+    ),
+    "decimal": (
+        "Decimal",
+        "decimal",
+        Decimal,                  # simply wraps the raw bytes/str → Decimal
+    ),
 }

--- a/resources/weather.avsc
+++ b/resources/weather.avsc
@@ -81,6 +81,15 @@
                 {"type": "map","values": "Weather"},
                 "null"
             ] 
-        }
+        },
+        {
+          "name": "tempdec",
+          "type": {
+            "type": "bytes",
+            "logicalType": "decimal",
+            "precision": 10,
+            "scale": 2
+          }
+        }        
     ]
 }

--- a/tests/test_from_dict.py
+++ b/tests/test_from_dict.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Union
+from decimal import Decimal
 from tests.utils import roundtrip
 
 
@@ -7,6 +8,14 @@ from tests.utils import roundtrip
 class Inner:
     a: str
 
+
+def test_decimal():
+    @dataclass
+    class Test:
+        amount: Decimal
+
+    test = Test(Decimal("1234.5678"))
+    assert test == roundtrip(test)
 
 def test_primitives():
     @dataclass

--- a/tests/test_generate_classes.py
+++ b/tests/test_generate_classes.py
@@ -5,6 +5,7 @@ import os
 import sys
 from contextlib import contextmanager
 from tests.utils import roundtrip
+from decimal import Decimal
 
 
 @contextmanager
@@ -62,6 +63,9 @@ def test_weather_roundtrip(tmp_path):
                 enum="EnumA",
                 record=Record(Field1="only field"),
                 circle=None,
+                tempdec=Decimal("36.67")
+
             ),
+            tempdec= Decimal("1234.5678")
         )
         assert record == roundtrip(record)


### PR DESCRIPTION
Also there is new LOGICAL_TYPE_MAP so it is easy to add any new type that doesn't work out of the box with the fast avro
```
LOGICAL_TYPE_MAP = {
    # logicalType: (typename, import-module, parse-expression)
    "decimal":        ("Decimal",        "decimal",        "Decimal(val)"),
    # add more as needed and if not supported by fast avro
}
```